### PR TITLE
Add a label for the Godot engine

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,6 +14,9 @@
 - name: L-github
   color: 34495e
   description: "Tag the GitHub ecosystem"
+- name: L-godot
+  color: 34495e
+  description: "Tag the Godot Engine ecosystem"
 - name: L-rust
   color: 34495e
   description: "Tag the Rust ecosystem"


### PR DESCRIPTION
A new GitHub issue label has been added for the Godot Engine so that we can tag pull requests that change the game itself.