### PR TITLE
Create the script for the player

### DIFF
--- a/godot/src/Actors/Player.gdns
+++ b/godot/src/Actors/Player.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://libraries/rust.tres" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "Player"
+class_name = "Player"
+library = ExtResource( 1 )

--- a/godot/src/Actors/Player.tscn
+++ b/godot/src/Actors/Player.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://assets/player.png" type="Texture" id=1]
+[ext_resource path="res://src/Actors/Player.gdns" type="Script" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 40, 44 )
 
 [node name="Player" type="KinematicBody2D"]
+script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]
 position = Vector2( 0, -48 )

--- a/src/actors/actor.rs
+++ b/src/actors/actor.rs
@@ -1,0 +1,45 @@
+use std::fmt::{Display, Formatter};
+
+use gdnative::prelude::*;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
+#[inherit(KinematicBody2D)]
+pub struct Actor;
+
+impl Actor {
+    pub fn new(_base: &KinematicBody2D) -> Self {
+        Actor
+    }
+}
+
+#[methods]
+impl Actor {}
+
+impl Display for Actor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Actor")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Actor>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Actor>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Actor>();
+    }
+}

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,0 +1,5 @@
+pub use self::actor::*;
+pub use self::player::*;
+
+mod actor;
+mod player;

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -1,0 +1,45 @@
+use std::fmt::Display;
+
+use gdnative::prelude::*;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
+#[inherit(KinematicBody2D)]
+pub struct Player;
+
+impl Player {
+    pub fn new(_base: &KinematicBody2D) -> Self {
+        Player
+    }
+}
+
+#[methods]
+impl Player {}
+
+impl Display for Player {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Player")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Player>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Player>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Player>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,12 @@ use gdnative::prelude::*;
 use godot_logger::GodotLogger;
 use log::{Level, LevelFilter};
 
+use crate::actors::{Actor, Player};
+
+mod actors;
+
 /// Registers all exposed classes to Godot
-fn init(_handle: InitHandle) {
+fn init(handle: InitHandle) {
     if let Err(error) = GodotLogger::builder()
         .default_log_level(Level::Debug)
         .add_filter("h2", LevelFilter::Error)
@@ -15,6 +19,9 @@ fn init(_handle: InitHandle) {
     } else {
         log::debug!("Initialized godot-logger");
     }
+
+    handle.add_class::<Actor>();
+    handle.add_class::<Player>();
 }
 
 // Macro that creates the entry-points of the dynamic library


### PR DESCRIPTION
A new script has been created for the player. The scripts extends the native `KinematicBody2D` class, and has been attached to the player scene.

Following the tutorial, another script has been created for actors in general. In GDScript, the player script inherits from this generic actor script. In Rust, this is not possible due to the lack of inheritance. When we see how the actor script is used in later parts of the tutorial, we will be able to decide how to deal with it in Rust. A potential solution might be to turn it into a `Trait` with default implementations for the shared behavior.