### PR TITLE
Move the player to the right

### DIFF
--- a/godot/src/Actors/Player.tscn
+++ b/godot/src/Actors/Player.tscn
@@ -7,6 +7,7 @@
 extents = Vector2( 40, 44 )
 
 [node name="Player" type="KinematicBody2D"]
+position = Vector2( 48, 600 )
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/src/actors/actor.rs
+++ b/src/actors/actor.rs
@@ -1,45 +1,19 @@
-use std::fmt::{Display, Formatter};
+use std::f64::consts::FRAC_PI_4;
 
 use gdnative::prelude::*;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
-#[inherit(KinematicBody2D)]
-pub struct Actor;
+pub trait Actor {
+    fn physics_process(&mut self, owner: &KinematicBody2D, _delta: f32) {
+        let horizontal_movement: Vector2 = Vector2::new(300.0, 0.0);
+        let vertical_movement: Vector2 = Vector2::ZERO;
 
-impl Actor {
-    pub fn new(_base: &KinematicBody2D) -> Self {
-        Actor
-    }
-}
-
-#[methods]
-impl Actor {}
-
-impl Display for Actor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Actor")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<Actor>();
-    }
-
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<Actor>();
-    }
-
-    #[test]
-    fn trait_unpin() {
-        fn assert_unpin<T: Unpin>() {}
-        assert_unpin::<Actor>();
+        owner.move_and_slide(
+            horizontal_movement,
+            vertical_movement,
+            false,
+            4,
+            FRAC_PI_4,
+            false,
+        );
     }
 }

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -2,6 +2,8 @@ use std::fmt::Display;
 
 use gdnative::prelude::*;
 
+use crate::actors::Actor;
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
 #[inherit(KinematicBody2D)]
 pub struct Player;
@@ -13,7 +15,14 @@ impl Player {
 }
 
 #[methods]
-impl Player {}
+impl Player {
+    #[method]
+    fn _physics_process(&mut self, #[base] owner: &KinematicBody2D, delta: f32) {
+        self.physics_process(owner, delta);
+    }
+}
+
+impl Actor for Player {}
 
 impl Display for Player {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use gdnative::prelude::*;
 use godot_logger::GodotLogger;
 use log::{Level, LevelFilter};
 
-use crate::actors::{Actor, Player};
+use crate::actors::Player;
 
 mod actors;
 
@@ -20,7 +20,6 @@ fn init(handle: InitHandle) {
         log::debug!("Initialized godot-logger");
     }
 
-    handle.add_class::<Actor>();
     handle.add_class::<Player>();
 }
 


### PR DESCRIPTION
The most basic form of movement has been implemented for the player. It simply moves them with a constant speed to the right.

As hypothesized earlier, the implementation for the `Actor` parent class has been changed to a `Trait` in Rust so that its behavior can be shared between Rust types.