### PR TITLE
Add gravity to the player

### DIFF
--- a/godot/src/Actors/Player.tscn
+++ b/godot/src/Actors/Player.tscn
@@ -7,7 +7,7 @@
 extents = Vector2( 40, 44 )
 
 [node name="Player" type="KinematicBody2D"]
-position = Vector2( 48, 600 )
+position = Vector2( 514, 154 )
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/src/actors/actor.rs
+++ b/src/actors/actor.rs
@@ -2,18 +2,18 @@ use std::f64::consts::FRAC_PI_4;
 
 use gdnative::prelude::*;
 
-pub trait Actor {
-    fn physics_process(&mut self, owner: &KinematicBody2D, _delta: f32) {
-        let horizontal_movement: Vector2 = Vector2::new(300.0, 0.0);
-        let vertical_movement: Vector2 = Vector2::ZERO;
+const GRAVITY: f32 = 3000.0;
 
-        owner.move_and_slide(
-            horizontal_movement,
-            vertical_movement,
-            false,
-            4,
-            FRAC_PI_4,
-            false,
-        );
+pub trait Actor {
+    fn velocity(&self) -> &Vector2;
+    fn set_velocity(&mut self, velocity: Vector2);
+
+    fn physics_process(&mut self, owner: &KinematicBody2D, delta: f32) {
+        let gravity = self.velocity().y + GRAVITY * delta;
+
+        let velocity = Vector2::new(self.velocity().x, gravity);
+        self.set_velocity(velocity);
+
+        owner.move_and_slide(velocity, Vector2::ZERO, false, 4, FRAC_PI_4, true);
     }
 }

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -4,13 +4,17 @@ use gdnative::prelude::*;
 
 use crate::actors::Actor;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, NativeClass)]
 #[inherit(KinematicBody2D)]
-pub struct Player;
+pub struct Player {
+    velocity: Vector2,
+}
 
 impl Player {
     pub fn new(_base: &KinematicBody2D) -> Self {
-        Player
+        Self {
+            velocity: Vector2::ZERO,
+        }
     }
 }
 
@@ -22,7 +26,15 @@ impl Player {
     }
 }
 
-impl Actor for Player {}
+impl Actor for Player {
+    fn velocity(&self) -> &Vector2 {
+        &self.velocity
+    }
+
+    fn set_velocity(&mut self, velocity: Vector2) {
+        self.velocity = velocity;
+    }
+}
 
 impl Display for Player {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
The player is now effected by gravity and falls down. This feature requires the kinetic body to know its previous speed. The player has a field now to track its own velocity, and the trait for actors has been extended to provide getter and setter methods for it.