### PR TITLE
Move the enemies

### DIFF
--- a/godot/src/Levels/LevelTemplate.tscn
+++ b/godot/src/Levels/LevelTemplate.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://assets/tileset.tres" type="TileSet" id=1]
 [ext_resource path="res://src/Actors/Player.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/Actors/Enemy.tscn" type="PackedScene" id=3]
 
 [node name="LevelTemplate" type="Node2D"]
 
@@ -15,3 +16,6 @@ tile_data = PoolIntArray( 0, 0, 0, 23, 0, 0, 65536, 0, 0, 65559, 0, 0, 131072, 0
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
 position = Vector2( 520, 375 )
+
+[node name="Enemy" parent="." instance=ExtResource( 3 )]
+position = Vector2( 1440, 660 )

--- a/src/actors/enemy.rs
+++ b/src/actors/enemy.rs
@@ -1,19 +1,52 @@
+use std::f64::consts::FRAC_PI_4;
 use std::fmt::Display;
 
 use gdnative::prelude::*;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, NativeClass)]
+use crate::actors::FLOOR_NORMAL;
+
+#[derive(Copy, Clone, PartialEq, Debug, Default, NativeClass)]
 #[inherit(KinematicBody2D)]
-pub struct Enemy {}
+pub struct Enemy {
+    #[property]
+    gravity: f32,
+
+    #[property]
+    speed: f32,
+
+    velocity: Vector2,
+}
 
 impl Enemy {
     fn new(_owner: &KinematicBody2D) -> Self {
-        Enemy {}
+        Enemy {
+            gravity: 1000.0,
+            speed: 400.0,
+            velocity: Vector2::ZERO,
+        }
     }
 }
 
 #[methods]
-impl Enemy {}
+impl Enemy {
+    #[method]
+    fn _ready(&mut self, #[base] _base: &KinematicBody2D) {
+        self.velocity.x = -self.speed
+    }
+
+    #[method]
+    fn _physics_process(&mut self, #[base] owner: &KinematicBody2D, delta: f32) {
+        self.velocity.y += self.gravity * delta;
+
+        if owner.is_on_wall() {
+            self.velocity.x *= -1.0;
+        }
+
+        self.velocity.y = owner
+            .move_and_slide(self.velocity, FLOOR_NORMAL, false, 4, FRAC_PI_4, true)
+            .y;
+    }
+}
 
 impl Display for Enemy {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,3 +1,5 @@
+use gdnative::prelude::*;
+
 pub use self::actor::*;
 pub use self::enemy::*;
 pub use self::player::*;
@@ -5,3 +7,5 @@ pub use self::player::*;
 mod actor;
 mod enemy;
 mod player;
+
+const FLOOR_NORMAL: Vector2 = Vector2::UP;

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -3,9 +3,7 @@ use std::fmt::Display;
 
 use gdnative::prelude::*;
 
-use crate::actors::Actor;
-
-const FLOOR_NORMAL: Vector2 = Vector2::UP;
+use crate::actors::{Actor, FLOOR_NORMAL};
 
 #[derive(Copy, Clone, PartialEq, Debug, Default, NativeClass)]
 #[inherit(KinematicBody2D)]
@@ -81,9 +79,7 @@ impl Player {
             delta,
         );
 
-        self.velocity = velocity;
-
-        owner.move_and_slide(velocity, FLOOR_NORMAL, false, 4, FRAC_PI_4, true);
+        self.velocity = owner.move_and_slide(velocity, FLOOR_NORMAL, false, 4, FRAC_PI_4, true);
     }
 }
 


### PR DESCRIPTION
The enemy type has been extended to support movement. By default, enemies move left towards the player until they hit an obstacle. When they collide with something, they turn around and move back in the opposite direction.