### PR TITLE
Disable enemies outside the view

### DIFF
--- a/godot/src/Actors/Enemy.tscn
+++ b/godot/src/Actors/Enemy.tscn
@@ -18,3 +18,8 @@ texture = ExtResource( 1 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2( 0, -37 )
 shape = SubResource( 1 )
+
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+rect = Rect2( -50, -60, 100, 60 )
+process_parent = true
+physics_process_parent = true

--- a/src/actors/enemy.rs
+++ b/src/actors/enemy.rs
@@ -30,7 +30,11 @@ impl Enemy {
 #[methods]
 impl Enemy {
     #[method]
-    fn _ready(&mut self, #[base] _base: &KinematicBody2D) {
+    fn _ready(&mut self, #[base] base: &KinematicBody2D) {
+        // Do not move enemy until it is visible
+        base.set_physics_process(false);
+
+        // Move the enemy leftwards towards the player
         self.velocity.x = -self.speed
     }
 


### PR DESCRIPTION
A visibility enabler has been added to enemies so that they do not move when they are outside the player's view. This prevents them from accidentally falling to their death prematurely, and ensures that the player will encounter enemies at the places where we drop them when building the level.