### PR TITLE
Despawn enemies when player jumps on them

### DIFF
--- a/godot/src/Actors/Enemy.tscn
+++ b/godot/src/Actors/Enemy.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://assets/enemy.png" type="Texture" id=1]
 [ext_resource path="res://src/Actors/Enemy.gdns" type="Script" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 45, 37 )
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 50, 10 )
 
 [node name="Enemy" type="KinematicBody2D"]
 collision_layer = 2
@@ -23,3 +26,14 @@ shape = SubResource( 1 )
 rect = Rect2( -50, -60, 100, 60 )
 process_parent = true
 physics_process_parent = true
+
+[node name="StompDetector" type="Area2D" parent="."]
+position = Vector2( 0, -75 )
+collision_layer = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StompDetector"]
+modulate = Color( 0.411765, 0.431373, 0.909804, 1 )
+position = Vector2( 0, -10 )
+shape = SubResource( 2 )
+
+[connection signal="body_entered" from="StompDetector" to="." method="on_stomp_detector_body_entered"]

--- a/src/actors/enemy.rs
+++ b/src/actors/enemy.rs
@@ -1,6 +1,7 @@
 use std::f64::consts::FRAC_PI_4;
 use std::fmt::Display;
 
+use gdnative::api::{CollisionShape2D, PhysicsBody2D};
 use gdnative::prelude::*;
 
 use crate::actors::FLOOR_NORMAL;
@@ -49,6 +50,27 @@ impl Enemy {
         self.velocity.y = owner
             .move_and_slide(self.velocity, FLOOR_NORMAL, false, 4, FRAC_PI_4, true)
             .y;
+    }
+
+    #[method]
+    fn on_stomp_detector_body_entered(&mut self, #[base] owner: &KinematicBody2D, body: Variant) {
+        let body = unsafe { body.try_to_object::<PhysicsBody2D>().unwrap().assume_safe() };
+
+        if body.global_position().y > owner.global_position().y {
+            return;
+        }
+
+        let collision_shape = unsafe {
+            owner
+                .get_node("CollisionShape2D")
+                .unwrap()
+                .assume_safe()
+                .cast::<CollisionShape2D>()
+                .unwrap()
+        };
+        collision_shape.set_deferred("disabled", true);
+
+        owner.queue_free();
     }
 }
 


### PR DESCRIPTION
When the player jumps on an enemy, the enemy dies and gets despawned. This is implemented using a collision shape on top of the enemy, and a signal that is sent whenever something collides with this shape. Because enemies can only collide with the player and the world, we know that only the player can have hit the top of the enemy.