### PR TITLE
Create scene for coins

### DIFF
--- a/godot/src/Objects/Coin.tscn
+++ b/godot/src/Objects/Coin.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://assets/coin.png" type="Texture" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 34.0147
+
+[node name="Coin" type="Area2D"]
+
+[node name="Coin" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]


### PR DESCRIPTION
A new scene with a coin has been created. The coin has a sprite and a collision shape as well as an (yet) empty animation player.